### PR TITLE
Update NucleiApi.py

### DIFF
--- a/Plugins/Vul/Nuclei/NucleiApi.py
+++ b/Plugins/Vul/Nuclei/NucleiApi.py
@@ -39,7 +39,7 @@ def run_nuclei(alive_Web):
     os.system(nucleiUpdateCMD)
 
     # 运行nuclei检测漏洞
-    nucleiCMD = '{}/nuclei -l {} {} -json -o {}'.format(nucleiFolder, urlFilePath, nuclei_config, nucleiResultPath)
+    nucleiCMD = '{}/nuclei -l {} {} -jsonl -o {}'.format(nucleiFolder, urlFilePath, nuclei_config, nucleiResultPath)
     print("[nucleiCMD] : {}".format(nucleiCMD))
     os.system(nucleiCMD)
 


### PR DESCRIPTION
更新参数 -jsonl 或者 -j   旧版nuclei不用更新，新版的已经不支持此参数了，如果此代码更新的话需要同步更新下nuclei为最新版